### PR TITLE
Various Delete extension methods

### DIFF
--- a/src/Ardalis.HttpClientTestExtensions/HttpClientDeleteExtensionMethods.cs
+++ b/src/Ardalis.HttpClientTestExtensions/HttpClientDeleteExtensionMethods.cs
@@ -23,8 +23,8 @@ public static partial class HttpClientDeleteExtensionMethods
   }
 
   public static async Task<HttpResponseMessage> DeleteAndEnsureNotFoundAsync(
-    this HttpClient client, 
-    string requestUri, 
+    this HttpClient client,
+    string requestUri,
     ITestOutputHelper output = null)
   {
     var response = await client.DeleteAsync(requestUri, output);
@@ -33,8 +33,8 @@ public static partial class HttpClientDeleteExtensionMethods
   }
 
   public static async Task<HttpResponseMessage> DeleteAndEnsureNoContentAsync(
-    this HttpClient client, 
-    string requestUri, 
+    this HttpClient client,
+    string requestUri,
     ITestOutputHelper output = null)
   {
     var response = await client.DeleteAsync(requestUri, output);
@@ -72,9 +72,19 @@ public static partial class HttpClientDeleteExtensionMethods
     return response;
   }
 
+  public static async Task<HttpResponseMessage> DeleteAndEnsureBadRequestAsync(
+    this HttpClient client,
+    string requestUri,
+    ITestOutputHelper output = null)
+  {
+    var response = await client.DeleteAsync(requestUri, output);
+    response.EnsureBadRequest();
+    return response;
+  }
+
   public static async Task<HttpResponseMessage> DeleteAsync(
-    this HttpClient client, 
-    string requestUri, 
+    this HttpClient client,
+    string requestUri,
     ITestOutputHelper output)
   {
     output?.WriteLine($"Requesting with DELETE {requestUri}");

--- a/src/Ardalis.HttpClientTestExtensions/HttpClientDeleteExtensionMethods.cs
+++ b/src/Ardalis.HttpClientTestExtensions/HttpClientDeleteExtensionMethods.cs
@@ -8,17 +8,33 @@ public static partial class HttpClientDeleteExtensionMethods
 {
   public static async Task<HttpResponseMessage> DeleteAndEnsureNotFoundAsync(this HttpClient client, string requestUri, ITestOutputHelper output = null)
   {
-    output?.WriteLine($"Requesting with DELETE {requestUri}");
-    var response = await client.DeleteAsync(requestUri);
+    var response = await client.DeleteAsync(requestUri, output);
     response.EnsureNotFound();
     return response;
   }
 
   public static async Task<HttpResponseMessage> DeleteAndEnsureNoContentAsync(this HttpClient client, string requestUri, ITestOutputHelper output = null)
   {
-    output?.WriteLine($"Requesting with DELETE {requestUri}");
-    var response = await client.DeleteAsync(requestUri);
+    var response = await client.DeleteAsync(requestUri, output);
     response.EnsureNoContent();
     return response;
+  }
+
+  public static async Task<string> DeleteAndEnsureSubstringAsync(this HttpClient client,
+    string requestUri,
+    string substring,
+    ITestOutputHelper output = null)
+  {
+    var response = await client.DeleteAsync(requestUri, output);
+    return await response.EnsureContainsAsync(substring);
+  }
+
+  public static async Task<HttpResponseMessage> DeleteAsync(
+    this HttpClient client, 
+    string requestUri, 
+    ITestOutputHelper output)
+  {
+    output?.WriteLine($"Requesting with DELETE {requestUri}");
+    return await client.DeleteAsync(requestUri);
   }
 }

--- a/src/Ardalis.HttpClientTestExtensions/HttpClientDeleteExtensionMethods.cs
+++ b/src/Ardalis.HttpClientTestExtensions/HttpClientDeleteExtensionMethods.cs
@@ -62,6 +62,16 @@ public static partial class HttpClientDeleteExtensionMethods
     return response;
   }
 
+  public static async Task<HttpResponseMessage> DeleteAndEnsureForbiddenAsync(
+    this HttpClient client,
+    string requestUri,
+    ITestOutputHelper output = null)
+  {
+    var response = await client.DeleteAsync(requestUri, output);
+    response.EnsureForbidden();
+    return response;
+  }
+
   public static async Task<HttpResponseMessage> DeleteAsync(
     this HttpClient client, 
     string requestUri, 

--- a/src/Ardalis.HttpClientTestExtensions/HttpClientDeleteExtensionMethods.cs
+++ b/src/Ardalis.HttpClientTestExtensions/HttpClientDeleteExtensionMethods.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
 
@@ -6,21 +7,43 @@ namespace Ardalis.HttpClientTestExtensions;
 
 public static partial class HttpClientDeleteExtensionMethods
 {
-  public static async Task<HttpResponseMessage> DeleteAndEnsureNotFoundAsync(this HttpClient client, string requestUri, ITestOutputHelper output = null)
+  public static async Task<T> DeleteAndDeserializeAsync<T>(
+    this HttpClient client,
+    string requestUri,
+    ITestOutputHelper output = null)
+  {
+    var response = await client.DeleteAsync(requestUri, output);
+    response.EnsureSuccessStatusCode();
+    var stringResponse = await response.Content.ReadAsStringAsync();
+    output?.WriteLine($"Response: {stringResponse}");
+    var result = JsonSerializer.Deserialize<T>(stringResponse,
+      Constants.DefaultJsonOptions);
+
+    return result;
+  }
+
+  public static async Task<HttpResponseMessage> DeleteAndEnsureNotFoundAsync(
+    this HttpClient client, 
+    string requestUri, 
+    ITestOutputHelper output = null)
   {
     var response = await client.DeleteAsync(requestUri, output);
     response.EnsureNotFound();
     return response;
   }
 
-  public static async Task<HttpResponseMessage> DeleteAndEnsureNoContentAsync(this HttpClient client, string requestUri, ITestOutputHelper output = null)
+  public static async Task<HttpResponseMessage> DeleteAndEnsureNoContentAsync(
+    this HttpClient client, 
+    string requestUri, 
+    ITestOutputHelper output = null)
   {
     var response = await client.DeleteAsync(requestUri, output);
     response.EnsureNoContent();
     return response;
   }
 
-  public static async Task<string> DeleteAndEnsureSubstringAsync(this HttpClient client,
+  public static async Task<string> DeleteAndEnsureSubstringAsync(
+    this HttpClient client,
     string requestUri,
     string substring,
     ITestOutputHelper output = null)

--- a/src/Ardalis.HttpClientTestExtensions/HttpClientDeleteExtensionMethods.cs
+++ b/src/Ardalis.HttpClientTestExtensions/HttpClientDeleteExtensionMethods.cs
@@ -52,6 +52,16 @@ public static partial class HttpClientDeleteExtensionMethods
     return await response.EnsureContainsAsync(substring);
   }
 
+  public static async Task<HttpResponseMessage> DeleteAndEnsureUnauthorizedAsync(
+    this HttpClient client,
+    string requestUri,
+    ITestOutputHelper output = null)
+  {
+    var response = await client.DeleteAsync(requestUri, output);
+    response.EnsureUnauthorized();
+    return response;
+  }
+
   public static async Task<HttpResponseMessage> DeleteAsync(
     this HttpClient client, 
     string requestUri, 

--- a/tests/Ardalis.HttpClientTestExtensions.Api/Endpoints/AuthEndpoints/Forbidden.cs
+++ b/tests/Ardalis.HttpClientTestExtensions.Api/Endpoints/AuthEndpoints/Forbidden.cs
@@ -6,9 +6,10 @@ namespace Ardalis.HttpClientTestExtensions.Api.Endpoints.AuthEndpoints;
 public class Forbidden : EndpointBaseSync
   .WithoutRequest
   .WithResult<ForbidResult>
-    
+
 {
-  [HttpGet("/forbid")]
+  [Route("/forbid")]
+  [AcceptVerbs("GET", "DELETE")]
   public override ForbidResult Handle()
   {
     return Forbid();

--- a/tests/Ardalis.HttpClientTestExtensions.Api/Endpoints/AuthEndpoints/Unauthorized.cs
+++ b/tests/Ardalis.HttpClientTestExtensions.Api/Endpoints/AuthEndpoints/Unauthorized.cs
@@ -7,7 +7,8 @@ public class Unauthorized : EndpointBaseSync
     .WithoutRequest
     .WithResult<UnauthorizedResult>
 {
-  [HttpGet("/unauthorized")]
+  [Route("/unauthorized")]
+  [AcceptVerbs("GET", "DELETE")]
   public override UnauthorizedResult Handle()
   {
     return Unauthorized();

--- a/tests/Ardalis.HttpClientTestExtensions.Api/Endpoints/CountryEndpoints/Delete.cs
+++ b/tests/Ardalis.HttpClientTestExtensions.Api/Endpoints/CountryEndpoints/Delete.cs
@@ -4,8 +4,8 @@ using Ardalis.ApiEndpoints;
 using AutoMapper;
 using Microsoft.AspNetCore.Mvc;
 using Ardalis.HttpClientTestExtensions.Core.Entities;
-using Ardalis.HttpClientTestExtensions.Core.Specifications;
 using Ardalis.HttpClientTestExtensions.SharedKernel.Interfaces;
+using Ardalis.HttpClientTestExtensions.Api.Dtos;
 
 namespace Ardalis.HttpClientTestExtensions.Api.Endpoints.CountryEndpoints;
 
@@ -13,10 +13,12 @@ public class Delete : EndpointBaseAsync
     .WithRequest<string>
     .WithActionResult<bool>
 {
+  private readonly IMapper _mapper;
   private readonly IRepository<Country> _repository;
 
-  public Delete(IRepository<Country> repository)
+  public Delete(IMapper mapper, IRepository<Country> repository)
   {
+    _mapper = mapper;
     _repository = repository;
   }
 
@@ -30,6 +32,8 @@ public class Delete : EndpointBaseAsync
     }
     await _repository.DeleteAsync(entity, cancellationToken);
 
-    return Ok(true);
+    var response = _mapper.Map<CountryDto>(entity);
+
+    return Ok(response);
   }
 }

--- a/tests/Ardalis.HttpClientTestExtensions.Api/Endpoints/ErrorEndpoints/BadRequest.cs
+++ b/tests/Ardalis.HttpClientTestExtensions.Api/Endpoints/ErrorEndpoints/BadRequest.cs
@@ -8,7 +8,8 @@ public class BadRequest : EndpointBaseSync
   .WithResult<BadRequestResult>
     
 {
-  [HttpGet("/badrequest")]
+  [Route("/badrequest")]
+  [AcceptVerbs("GET", "DELETE")]
   public override BadRequestResult Handle()
   {
     return BadRequest();

--- a/tests/Ardalis.HttpClientTestExtensions.Tests/HttpClientDeleteExtensionMethodsTests.cs
+++ b/tests/Ardalis.HttpClientTestExtensions.Tests/HttpClientDeleteExtensionMethodsTests.cs
@@ -1,6 +1,8 @@
 ﻿using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Ardalis.HttpClientTestExtensions.Api;
+using Ardalis.HttpClientTestExtensions.Api.Dtos;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,6 +18,18 @@ public class HttpClientDeleteExtensionMethodsTests : IClassFixture<CustomWebAppl
   {
     _client = factory.CreateClient();
     _outputHelper = outputHelper;
+  }
+
+  [Fact]
+  public async Task DeleteAndDeserializeTestAsync()
+  {
+    var expectedId = SeedData.TestCountry2.Id;
+    var expectedName = SeedData.TestCountry2.Name;
+
+    var response = await _client.DeleteAndDeserializeAsync<CountryDto>("/countries/KSA", _outputHelper);
+
+    response.Id.ShouldBe(expectedId);
+    response.Name.ShouldBe(expectedName);
   }
 
   [Fact]
@@ -36,9 +50,10 @@ public class HttpClientDeleteExtensionMethodsTests : IClassFixture<CustomWebAppl
   [Fact]
   public async Task DeleteAndEnsureSubstringAsync_With_Matching_Substring()
   {
-    var response = await _client.DeleteAndEnsureSubstringAsync("/countries/USA", "ru", _outputHelper);
+    var expectedJson = "{\"id\":\"USA\",\"name\":\"USA\"}";
+    var response = await _client.DeleteAndEnsureSubstringAsync("/countries/USA", "USA", _outputHelper);
 
-    response.ShouldBe("true");
+    response.ShouldBe(expectedJson);
   }
 
   [Fact]

--- a/tests/Ardalis.HttpClientTestExtensions.Tests/HttpClientDeleteExtensionMethodsTests.cs
+++ b/tests/Ardalis.HttpClientTestExtensions.Tests/HttpClientDeleteExtensionMethodsTests.cs
@@ -61,4 +61,10 @@ public class HttpClientDeleteExtensionMethodsTests : IClassFixture<CustomWebAppl
   {
     await Assert.ThrowsAsync<HttpRequestException>(() => _client.DeleteAndEnsureSubstringAsync("/countries/USA", "banana", _outputHelper));
   }
+
+  [Fact]
+  public async Task DeleteAndEnsureUnauthorizedAsync()
+  {
+    _ = await _client.DeleteAndEnsureUnauthorizedAsync("/unauthorized", _outputHelper);
+  }
 }

--- a/tests/Ardalis.HttpClientTestExtensions.Tests/HttpClientDeleteExtensionMethodsTests.cs
+++ b/tests/Ardalis.HttpClientTestExtensions.Tests/HttpClientDeleteExtensionMethodsTests.cs
@@ -32,4 +32,18 @@ public class HttpClientDeleteExtensionMethodsTests : IClassFixture<CustomWebAppl
   {
     _ = await _client.DeleteAndEnsureNoContentAsync("/countries/4", _outputHelper);
   }
+
+  [Fact]
+  public async Task DeleteAndEnsureSubstringAsync_With_Matching_Substring()
+  {
+    var response = await _client.DeleteAndEnsureSubstringAsync("/countries/USA", "ru", _outputHelper);
+
+    response.ShouldBe("true");
+  }
+
+  [Fact]
+  public async Task DeleteAndEnsureSubstringAsync_Without_Matching_Substring()
+  {
+    await Assert.ThrowsAsync<HttpRequestException>(() => _client.DeleteAndEnsureSubstringAsync("/countries/USA", "banana", _outputHelper));
+  }
 }

--- a/tests/Ardalis.HttpClientTestExtensions.Tests/HttpClientDeleteExtensionMethodsTests.cs
+++ b/tests/Ardalis.HttpClientTestExtensions.Tests/HttpClientDeleteExtensionMethodsTests.cs
@@ -67,4 +67,10 @@ public class HttpClientDeleteExtensionMethodsTests : IClassFixture<CustomWebAppl
   {
     _ = await _client.DeleteAndEnsureUnauthorizedAsync("/unauthorized", _outputHelper);
   }
+
+  [Fact]
+  public async Task DeleteAndEnsureForbiddenAsync()
+  {
+    _ = await _client.DeleteAndEnsureForbiddenAsync("/forbid", _outputHelper);
+  }
 }

--- a/tests/Ardalis.HttpClientTestExtensions.Tests/HttpClientDeleteExtensionMethodsTests.cs
+++ b/tests/Ardalis.HttpClientTestExtensions.Tests/HttpClientDeleteExtensionMethodsTests.cs
@@ -73,4 +73,10 @@ public class HttpClientDeleteExtensionMethodsTests : IClassFixture<CustomWebAppl
   {
     _ = await _client.DeleteAndEnsureForbiddenAsync("/forbid", _outputHelper);
   }
+
+  [Fact]
+  public async Task DeleteAndEnsureBadRequestAsync()
+  {
+    _ = await _client.DeleteAndEnsureBadRequestAsync("/badrequest", _outputHelper);
+  }
 }


### PR DESCRIPTION
- [Add DeleteAndEnsureSubstringAsync](https://github.com/ardalis/HttpClientTestExtensions/commit/329f961689d4106e94a7b46d25baf0774c8375db) closes #11 
- [Add DeleteAndDeserializeAsync](https://github.com/ardalis/HttpClientTestExtensions/pull/28/commits/7aaa35b8b7afe48f974a7a93ef7f71cdf5ad748f) closes #12 
- [Add DeleteAndEnsureUnauthorizedAsync](https://github.com/ardalis/HttpClientTestExtensions/pull/28/commits/38b4e68094fba5568be0c12bc9ab33db5824598a) closes #14 
- [Add DeleteAndEnsureForbiddenAsync](https://github.com/ardalis/HttpClientTestExtensions/pull/28/commits/7814cd58079205fbe3878e3c9f0c4e1733780357) closes #16 
- [Add DeleteAndEnsureBadRequestAsync](https://github.com/ardalis/HttpClientTestExtensions/pull/28/commits/705a3946e15d220ed4999b9c3e30cbc224b6c893) closes #17 