### PR TITLE
Various PUT extension methods

### DIFF
--- a/src/Ardalis.HttpClientTestExtensions/HttpClientPutExtensionMethods.cs
+++ b/src/Ardalis.HttpClientTestExtensions/HttpClientPutExtensionMethods.cs
@@ -89,6 +89,17 @@ public static partial class HttpClientPutExtensionMethods
     return await response.EnsureContainsAsync(substring);
   }
 
+  public static async Task<HttpResponseMessage> PutAndEnsureBadRequestAsync(
+    this HttpClient client,
+    string requestUri,
+    HttpContent content,
+    ITestOutputHelper output = null)
+  {
+    var response = await client.PutAsync(requestUri, content, output);
+    response.EnsureBadRequest();
+    return response;
+  }
+
   public static async Task<HttpResponseMessage> PutAsync(
     this HttpClient client, 
     string requestUri,

--- a/src/Ardalis.HttpClientTestExtensions/HttpClientPutExtensionMethods.cs
+++ b/src/Ardalis.HttpClientTestExtensions/HttpClientPutExtensionMethods.cs
@@ -37,8 +37,7 @@ public static partial class HttpClientPutExtensionMethods
     HttpContent content,
     ITestOutputHelper output = null)
   {
-    output?.WriteLine($"Requesting with PUT {requestUri}");
-    var response = await client.PutAsync(requestUri, content);
+    var response = await client.PutAsync(requestUri, content, output);
     response.EnsureNotFound();
     return response;
   }
@@ -56,8 +55,7 @@ public static partial class HttpClientPutExtensionMethods
   HttpContent content,
   ITestOutputHelper output = null)
   {
-    output?.WriteLine($"Requesting with PUT {requestUri}");
-    var response = await client.PutAsync(requestUri, content);
+    var response = await client.PutAsync(requestUri, content, output);
     response.EnsureUnauthorized();
     return response;
   }
@@ -75,10 +73,20 @@ public static partial class HttpClientPutExtensionMethods
   HttpContent content,
   ITestOutputHelper output = null)
   {
-    output?.WriteLine($"Requesting with PUT {requestUri}");
-    var response = await client.PutAsync(requestUri, content);
+    var response = await client.PutAsync(requestUri, content, output);
     response.EnsureForbidden();
     return response;
+  }
+
+  public static async Task<string> PutAndEnsureSubstringAsync(
+    this HttpClient client,
+    string requestUri,
+    HttpContent content,
+    string substring,
+    ITestOutputHelper output = null)
+  {
+    var response = await client.PutAsync(requestUri, content, output);
+    return await response.EnsureContainsAsync(substring);
   }
 
   public static async Task<HttpResponseMessage> PutAsync(

--- a/src/Ardalis.HttpClientTestExtensions/HttpClientPutExtensionMethods.cs
+++ b/src/Ardalis.HttpClientTestExtensions/HttpClientPutExtensionMethods.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
 
@@ -6,6 +7,23 @@ namespace Ardalis.HttpClientTestExtensions;
 
 public static partial class HttpClientPutExtensionMethods
 {
+  public static async Task<T> PutAndDeserializeAsync<T>(
+    this HttpClient client,
+    string requestUri,
+    HttpContent content,
+    ITestOutputHelper output = null)
+  {
+    var response = await client.PutAsync(requestUri, content, output);
+    response.EnsureSuccessStatusCode();
+    var stringResponse = await response.Content.ReadAsStringAsync();
+    output?.WriteLine($"Response: {stringResponse}");
+    var result = JsonSerializer.Deserialize<T>(stringResponse,
+      Constants.DefaultJsonOptions);
+
+    return result;
+  }
+
+
   /// <summary>
   /// Ensures a PUT to a requestUri returns a 401 Unauthorized response status code
   /// </summary>
@@ -61,6 +79,16 @@ public static partial class HttpClientPutExtensionMethods
     var response = await client.PutAsync(requestUri, content);
     response.EnsureForbidden();
     return response;
+  }
+
+  public static async Task<HttpResponseMessage> PutAsync(
+    this HttpClient client, 
+    string requestUri,
+    HttpContent content, 
+    ITestOutputHelper output)
+  {
+    output?.WriteLine($"Requesting with PUT {requestUri}");
+    return await client.PutAsync(requestUri, content);
   }
 
 }

--- a/tests/Ardalis.HttpClientTestExtensions.Api/Endpoints/CountryEndpoints/Edit.cs
+++ b/tests/Ardalis.HttpClientTestExtensions.Api/Endpoints/CountryEndpoints/Edit.cs
@@ -5,7 +5,6 @@ using AutoMapper;
 using Microsoft.AspNetCore.Mvc;
 using Ardalis.HttpClientTestExtensions.Api.Dtos;
 using Ardalis.HttpClientTestExtensions.Core.Entities;
-using Ardalis.HttpClientTestExtensions.Core.Specifications;
 using Ardalis.HttpClientTestExtensions.SharedKernel.Interfaces;
 
 namespace Ardalis.HttpClientTestExtensions.Api.Endpoints.CountryEndpoints;
@@ -33,7 +32,7 @@ public class Edit : EndpointBaseAsync
     {
       return NotFound();
     }
-    var entityToSave = _mapper.Map<Country>(countryDto);
+    var entityToSave = _mapper.Map(countryDto, entity);
     await _repository.UpdateAsync(entityToSave, cancellationToken);
 
     var response = _mapper.Map<CountryDto>(entityToSave);

--- a/tests/Ardalis.HttpClientTestExtensions.Api/Endpoints/ErrorEndpoints/BadRequest.cs
+++ b/tests/Ardalis.HttpClientTestExtensions.Api/Endpoints/ErrorEndpoints/BadRequest.cs
@@ -9,7 +9,7 @@ public class BadRequest : EndpointBaseSync
     
 {
   [Route("/badrequest")]
-  [AcceptVerbs("GET", "DELETE")]
+  [AcceptVerbs("GET", "DELETE", "PUT")]
   public override BadRequestResult Handle()
   {
     return BadRequest();

--- a/tests/Ardalis.HttpClientTestExtensions.Tests/HttpClientPutExtensionMethodsTests.cs
+++ b/tests/Ardalis.HttpClientTestExtensions.Tests/HttpClientPutExtensionMethodsTests.cs
@@ -64,4 +64,12 @@ public class HttpClientPutExtensionMethodsTests : IClassFixture<CustomWebApplica
 
     await Assert.ThrowsAsync<HttpRequestException>(() => _client.PutAndEnsureSubstringAsync("/countries", content, "banana", _outputHelper));
   }
+
+  [Fact]
+  public async Task PutAndEnsureBadRequestAsync()
+  {
+    var dto = new CountryDto { Id = SeedData.TestCountry1.Id, Name = "'Merica" };
+    var content = new StringContent(JsonSerializer.Serialize(dto), Encoding.UTF8, "application/json");
+    _ = await _client.PutAndEnsureBadRequestAsync("/badrequest", content, _outputHelper);
+  }
 }

--- a/tests/Ardalis.HttpClientTestExtensions.Tests/HttpClientPutExtensionMethodsTests.cs
+++ b/tests/Ardalis.HttpClientTestExtensions.Tests/HttpClientPutExtensionMethodsTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Ardalis.HttpClientTestExtensions.Api;
 using Ardalis.HttpClientTestExtensions.Api.Dtos;
 using Shouldly;
 using Xunit;
@@ -22,7 +23,23 @@ public class HttpClientPutExtensionMethodsTests : IClassFixture<CustomWebApplica
   }
 
   [Fact]
-  public async Task PostAndEnsureNotFoundTestAsync()
+  public async Task PutAndDeserializeTestAsync()
+  {
+    var expectedId = SeedData.TestCountry1.Id;
+    var expectedName = "United States of America";
+    // var dto = await _client.GetAndDeserializeAsync<CountryDto>("/countries/USA", _outputHelper);
+    // dto.Name = expectedName;
+    var dto = new CountryDto { Id = expectedId, Name = expectedName };
+    var content = new StringContent(JsonSerializer.Serialize(dto), Encoding.UTF8, "application/json");
+
+    var response = await _client.PutAndDeserializeAsync<CountryDto>("/countries", content, _outputHelper);
+
+    response.Id.ShouldBe(expectedId);
+    response.Name.ShouldBe(expectedName);
+  }
+
+  [Fact]
+  public async Task PutAndEnsureNotFoundTestAsync()
   {
     var dto = new CountryDto();
     var content = new StringContent(JsonSerializer.Serialize(dto), Encoding.UTF8, "application/json");

--- a/tests/Ardalis.HttpClientTestExtensions.Tests/HttpClientPutExtensionMethodsTests.cs
+++ b/tests/Ardalis.HttpClientTestExtensions.Tests/HttpClientPutExtensionMethodsTests.cs
@@ -27,8 +27,6 @@ public class HttpClientPutExtensionMethodsTests : IClassFixture<CustomWebApplica
   {
     var expectedId = SeedData.TestCountry1.Id;
     var expectedName = "United States of America";
-    // var dto = await _client.GetAndDeserializeAsync<CountryDto>("/countries/USA", _outputHelper);
-    // dto.Name = expectedName;
     var dto = new CountryDto { Id = expectedId, Name = expectedName };
     var content = new StringContent(JsonSerializer.Serialize(dto), Encoding.UTF8, "application/json");
 
@@ -44,5 +42,26 @@ public class HttpClientPutExtensionMethodsTests : IClassFixture<CustomWebApplica
     var dto = new CountryDto();
     var content = new StringContent(JsonSerializer.Serialize(dto), Encoding.UTF8, "application/json");
     _ = await _client.PutAndEnsureNotFoundAsync("/wrongendpoint", content, _outputHelper);
+  }
+
+  [Fact]
+  public async Task PuAndEnsureSubstringAsync_With_Matching_Substring()
+  {
+    var expectedJson = "{\"id\":\"USA\",\"name\":\"'Merica\"}";
+    var dto = new CountryDto { Id = SeedData.TestCountry1.Id, Name = "'Merica" };
+    var content = new StringContent(JsonSerializer.Serialize(dto), Encoding.UTF8, "application/json");
+
+    var response = await _client.PutAndEnsureSubstringAsync("/countries", content, "erica", _outputHelper);
+
+    response.ShouldBe(expectedJson);
+  }
+
+  [Fact]
+  public async Task PutAndEnsureSubstringAsync_Without_Matching_Substring()
+  {
+    var dto = new CountryDto { Id = SeedData.TestCountry1.Id, Name = "'Merica" };
+    var content = new StringContent(JsonSerializer.Serialize(dto), Encoding.UTF8, "application/json");
+
+    await Assert.ThrowsAsync<HttpRequestException>(() => _client.PutAndEnsureSubstringAsync("/countries", content, "banana", _outputHelper));
   }
 }


### PR DESCRIPTION
- [Add PutAndDeserializeAsync](https://github.com/ardalis/HttpClientTestExtensions/commit/5f00f26a4923864a0eded0f65b504ce90d366a4b) closes #23 
- [Add PutAndEnsureSubstringAsync](https://github.com/ardalis/HttpClientTestExtensions/pull/29/commits/56b7f205889a792b2a2304109bc0f65361e43697) closes #18 
- [Add PutAndEnsureBadRequestAsync](https://github.com/ardalis/HttpClientTestExtensions/pull/29/commits/5ab4ef2448a4cce5d60a9783cf85295246fec4c6) closes #26 