### PR TITLE
Update HttpClientHelperExtensionMethods.cs

### DIFF
--- a/src/Ardalis.HttpClientTestExtensions/HttpClientHelperExtensionMethods.cs
+++ b/src/Ardalis.HttpClientTestExtensions/HttpClientHelperExtensionMethods.cs
@@ -21,7 +21,7 @@ public static partial class HttpClientHelperExtensionMethods
   /// <returns></returns>
   public static void EnsureNoAutoRedirect(this HttpClient client, ITestOutputHelper output = null)
   {
-    output.WriteLine($"Ensuring HttpClient does not auto-redirect");
+    output?.WriteLine($"Ensuring HttpClient does not auto-redirect");
     var handler = client.GetType().BaseType.GetField("_handler", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(client);
     if (handler.GetType() == typeof(RedirectHandler)) 
     {


### PR DESCRIPTION
fixed null reference exception in EnsureNoAutoRedirect when ITestOutputHelper parameter is null

#34 